### PR TITLE
add %version_tag% token

### DIFF
--- a/Fody/FormatStringTokenResolver.cs
+++ b/Fody/FormatStringTokenResolver.cs
@@ -34,6 +34,8 @@ public class FormatStringTokenResolver
         template = template.Replace("%user%", FormatUserName());
         template = template.Replace("%machine%", Environment.MachineName);
 
+        template = template.Replace("%version_tag%", repo.FindVersionTag());
+
         template = reEnvironmentToken.Replace(template, FormatEnvironmentVariable);
         template = reNow.Replace(template, FormatTime);
         template = reUtcNow.Replace(template, FormatUtcTime);

--- a/Fody/LibGitEx.cs
+++ b/Fody/LibGitEx.cs
@@ -1,4 +1,5 @@
-﻿using LibGit2Sharp;
+﻿using System.Linq;
+using LibGit2Sharp;
 
 public static class LibGitEx
 {
@@ -12,4 +13,17 @@ public static class LibGitEx
 			repositoryStatus.Removed.IsEmpty() &&
 			repositoryStatus.Staged.IsEmpty();	
 	}
+
+    public static string FindVersionTag(this Repository repository) {
+        var tagMap = repository.Tags
+            .Where(t => t.Target is Commit)
+            .ToDictionary(t => (Commit) t.Target);
+
+        return repository.Commits.QueryBy(new CommitFilter {
+                SortBy = CommitSortStrategies.Topological
+            })
+            .Where(c => tagMap.ContainsKey(c))
+            .Select(c => tagMap[c].FriendlyName.Trim().TrimStart('v'))
+            .FirstOrDefault();
+    }
 }


### PR DESCRIPTION
Hi!

I have a repo which uses tags of format `vX.X.X.X` to denote release versions, and I need to use these tags instead of assembly versions (as constantly changing latter was pretty cumbersome).

I did quick implementation of this and I'd like to share it in case anyone would need such thing. Probably could be implemented in a better way.