### PR TITLE
Support for `UseFileVersion` and `OverwriteFileVersion`

### DIFF
--- a/AssemblyToProcess/AssemblyInfo.cs
+++ b/AssemblyToProcess/AssemblyInfo.cs
@@ -3,4 +3,5 @@
 [assembly: AssemblyTitle("AssemblyToProcess")]
 [assembly: AssemblyProduct("AssemblyToProcess")]
 [assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("4.5.6.7")]
 //[assembly: AssemblyInformationalVersionAttribute("1.0.0.0/aString")]

--- a/AssemblyToProcessExistingAttribute/AssemblyInfo.cs
+++ b/AssemblyToProcessExistingAttribute/AssemblyInfo.cs
@@ -3,4 +3,5 @@
 [assembly: AssemblyTitle("AssemblyToProcessExistingAttribute")]
 [assembly: AssemblyProduct("AssemblyToProcessExistingAttribute")]
 [assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyFileVersion("4.5.6.7")]
 [assembly: AssemblyInformationalVersionAttribute("%version3%+%branch%.%githash% %haschanges% %utcnow% %now:yyMMdd%")]

--- a/Fody/Configuration.cs
+++ b/Fody/Configuration.cs
@@ -4,6 +4,8 @@ using System.Xml.Linq;
 public class Configuration
 {
     public bool UseProject;
+    public bool UseFileVersion;
+    public bool OverwriteFileVersion = true;
     public string ChangeString = "HasChanges";
 
     public Configuration(XElement config)
@@ -14,22 +16,50 @@ public class Configuration
         }
 
         var attr = config.Attribute("UseProjectGit");
-        if (attr != null)
+        if (HasValue(attr))
         {
-            try
-            {
-                UseProject = Convert.ToBoolean(attr.Value);
-            }
-            catch (Exception)
-            {
-                throw new WeavingException($"Unable to parse '{attr.Value}' as a boolean, please use true or false.");
-            }
+            UseProject = ConvertAndThrowIfNotBoolean(attr.Value);
+        }
+
+        attr = config.Attribute("UseFileVersion");
+        if (HasValue(attr))
+        {
+            UseFileVersion = ConvertAndThrowIfNotBoolean(attr.Value);
         }
 
         attr = config.Attribute("ChangeString");
-        if (!string.IsNullOrWhiteSpace(attr?.Value))
+        if (HasValue(attr))
         {
             ChangeString = attr.Value;
+        }
+
+        if (UseFileVersion)
+            OverwriteFileVersion = false;
+        else
+        {
+            attr = config.Attribute("OverwriteFileVersion");
+            if (HasValue(attr))
+            {
+                OverwriteFileVersion = ConvertAndThrowIfNotBoolean(attr.Value);
+            }
+        }
+    }
+
+    private static bool HasValue(XAttribute attr)
+    {
+        return !string.IsNullOrWhiteSpace(attr?.Value);
+    }
+
+    private static bool ConvertAndThrowIfNotBoolean(string value)
+    {
+        try
+        {
+            var result = Convert.ToBoolean(value);
+            return result;
+        }
+        catch
+        {
+            throw new WeavingException($"Unable to parse '{value}' as a boolean; please use 'true' or 'false'.");
         }
     }
 }

--- a/Fody/FormatStringTokenResolver.cs
+++ b/Fody/FormatStringTokenResolver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using LibGit2Sharp;
+using Mono.Cecil;
 
 public class FormatStringTokenResolver
 {
@@ -10,6 +11,12 @@ public class FormatStringTokenResolver
 
     private static DateTime now = DateTime.Now;
     private static DateTime utcNow = DateTime.UtcNow;
+
+    [Obsolete("Use ReplaceTokens with Version. Will be removed in 2.0")]
+    public string ReplaceTokens(string template, ModuleDefinition moduleDefinition, Repository repo, string changestring)
+    {
+        return ReplaceTokens(template, moduleDefinition.Assembly.Name.Version, repo, changestring);
+    }
 
     public string ReplaceTokens(string template, System.Version version, Repository repo, string changestring)
     {

--- a/Fody/FormatStringTokenResolver.cs
+++ b/Fody/FormatStringTokenResolver.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using LibGit2Sharp;
-using Mono.Cecil;
 
 public class FormatStringTokenResolver
 {
@@ -12,16 +11,15 @@ public class FormatStringTokenResolver
     private static DateTime now = DateTime.Now;
     private static DateTime utcNow = DateTime.UtcNow;
 
-    public string ReplaceTokens(string template, ModuleDefinition moduleDefinition, Repository repo, string changestring)
+    public string ReplaceTokens(string template, System.Version version, Repository repo, string changestring)
     {
-        var assemblyVersion = moduleDefinition.Assembly.Name.Version;
         var branch = repo.Head;
 
-        template = template.Replace("%version%", assemblyVersion.ToString());
-        template = template.Replace("%version1%", assemblyVersion.ToString(1));
-        template = template.Replace("%version2%", assemblyVersion.ToString(2));
-        template = template.Replace("%version3%", assemblyVersion.ToString(3));
-        template = template.Replace("%version4%", assemblyVersion.ToString(4));
+        template = template.Replace("%version%", version.ToString());
+        template = template.Replace("%version1%", version.ToString(1));
+        template = template.Replace("%version2%", version.ToString(2));
+        template = template.Replace("%version3%", version.ToString(3));
+        template = template.Replace("%version4%", version.ToString(4));
 
         template = template.Replace("%now%", now.ToShortDateString());
         template = template.Replace("%utcnow%", utcNow.ToShortDateString());

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -226,7 +226,7 @@ public class ModuleWeaver
         }
         catch (Exception ex)
         {
-            throw new WeavingException($"Failed to update the assembly information. {ex.Message}");
+            throw new WeavingException("Failed to update the assembly information. {ex.Message}", ex);
         }
     }
 

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -37,8 +37,8 @@ public class ModuleWeaver
 
     private Configuration _config;
 
-    private const string InfoAttributeName = "AssemblyInformationalVersionAttribute";
-    private const string FileAttributeName = "AssemblyFileVersionAttribute";
+    private const string InfoAttributeName = nameof(System.Reflection.AssemblyInformationalVersionAttribute);
+    private const string FileAttributeName = nameof(System.Reflection.AssemblyFileVersionAttribute);
 
     public ModuleWeaver()
     {

--- a/Fody/WeavingException.cs
+++ b/Fody/WeavingException.cs
@@ -7,4 +7,9 @@ public class WeavingException : Exception
     {
 
     }
+
+    /// <inheritdoc />
+    public WeavingException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Extracts the git information from disk, combines it with the assembly version, a
 So if your assembly version is `1.0.0.0`, the working branch is `master` and the last commit is `759e9ddb53271dfa9335a3b27e452749a9b22280` then the following attribute will be added to the assembly.
 
 ```c#
-[assembly: AssemblyInformationalVersion("1.0.0.0 Head:'master' Sha:759e9ddb53271dfa9335a3b27e452749a9b22280")]
+    [assembly: AssemblyInformationalVersion("1.0.0.0 Head:'master' Sha:759e9ddb53271dfa9335a3b27e452749a9b22280")]
 ```
 
 
@@ -50,6 +50,8 @@ The tokens are:
 - `%version2%` is replaced with the major and minor version (`1.0`)
 - `%version3%` is replaced with the major, minor, and revision version (`1.0.0`)
 - `%version4%` is replaced with the major, minor, revision, and build version (`1.0.0.0`)
+- `%now%` is replaced with the current short date
+- `%utcnow%` is replaced with the current utc short date
 - `%now%` is replaced with the current short date
 - `%utcnow%` is replaced with the current utc short date
 - `%githash%` is replaced with the SHA1 hash of the branch tip of the repository
@@ -78,7 +80,6 @@ Define the string used to indicate that the code was built from a non clean repo
 <Stamp ChangeString="New text" />
 ```
 
-
 ### UseProjectGit
 
 Define if you want to start Stamp to start searching for the Git repository in the ProjectDir (`true`) or the SolutionDir (`false`).
@@ -89,6 +90,24 @@ Define if you want to start Stamp to start searching for the Git repository in t
 <Stamp UseProjectGit='true' />
 ```
 
+### OverwriteFileVersion
+
+By default, Stamp will overwrite the `AssemblyFileVersion` with the `AssemblyVersion`. Setting this to `false` will preserve the existing `AssemblyFileVersion`.
+
+*Default is `true`*
+
+```xml
+<Stamp OverwriteFileVersion='false' />
+```
+
+### UseFileVersion
+
+By default, Stamp uses the value from `AssemblyVersion` to construct the `AssemblyInformationalVersion`. Set this to `true` to use the `AssemblyFileVersion` instead. **Note:** If this is set to `true`, `OverwriteFileVersion` will be `false` and will ignore any value explicitly set.
+
+*Default is `false`*
+```xml
+<Stamp UseFileVersion='true' />
+```
 
 ## Icon
 

--- a/Tests/TaskTests.cs
+++ b/Tests/TaskTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Reflection;
 using Mono.Cecil;
 using NUnit.Framework;
+using System.Xml.Linq;
+using System;
 
 [TestFixture]
 public class TaskTests
@@ -12,19 +14,25 @@ public class TaskTests
     // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
     private string beforeAssemblyPath;
     private string afterAssemblyPath;
+    protected XElement config;
 
-    public TaskTests()
+    [OneTimeSetUp]
+    public void Setup()
     {
         beforeAssemblyPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, @"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll"));
 #if (!DEBUG)
         beforeAssemblyPath = beforeAssemblyPath.Replace("Debug", "Release");
 #endif
 
-        afterAssemblyPath = beforeAssemblyPath.Replace(".dll", "2.dll");
+        afterAssemblyPath = beforeAssemblyPath.Replace(".dll", $"{Guid.NewGuid().ToString()}.dll");
         File.Copy(beforeAssemblyPath, afterAssemblyPath, true);
 
         using (var moduleDefinition = ModuleDefinition.ReadModule(beforeAssemblyPath))
         {
+
+            var versionInfo = FileVersionInfo.GetVersionInfo(afterAssemblyPath);
+            Trace.WriteLine($"Before: AssemblyVersion={moduleDefinition.Assembly.Name.Version}, FileVersion={versionInfo.FileVersion}, Config={config}");
+
             var currentDirectory = AssemblyLocation.CurrentDirectory();
 
             var weavingTask = new ModuleWeaver
@@ -33,6 +41,7 @@ public class TaskTests
                 AddinDirectoryPath = currentDirectory,
                 SolutionDirectoryPath = currentDirectory,
                 AssemblyFilePath = afterAssemblyPath,
+                Config = config
             };
 
             weavingTask.Execute();
@@ -44,16 +53,15 @@ public class TaskTests
         assembly = Assembly.LoadFile(afterAssemblyPath);
     }
 
-
     [Test]
     public void EnsureAttributeExists()
     {
         var customAttributes = (AssemblyInformationalVersionAttribute)assembly
-            .GetCustomAttributes(typeof (AssemblyInformationalVersionAttribute), false)
+            .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
             .First();
         Assert.IsNotNull(customAttributes.InformationalVersion);
         Assert.IsNotEmpty(customAttributes.InformationalVersion);
-        Trace.WriteLine(customAttributes.InformationalVersion);
+        Trace.WriteLine($"InfoVersion: {customAttributes.InformationalVersion}");
     }
 
     [Test]
@@ -64,8 +72,8 @@ public class TaskTests
         Assert.IsNotEmpty(versionInfo.ProductVersion);
         Assert.IsNotNull(versionInfo.FileVersion);
         Assert.IsNotEmpty(versionInfo.FileVersion);
-        Trace.WriteLine(versionInfo.ProductVersion);
-        Trace.WriteLine(versionInfo.FileVersion);
+        Trace.WriteLine($"ProductVersion: {versionInfo.ProductVersion}");
+        Trace.WriteLine($"FileVersion: {versionInfo.FileVersion}");
     }
 
 
@@ -77,4 +85,22 @@ public class TaskTests
     }
 #endif
 
+}
+
+[TestFixture]
+class UseFileVersionTests : TaskTests
+{
+    public UseFileVersionTests()
+    {
+        config = XElement.Parse("<Stamp UseFileVersion=\"true\" />");
+    }
+}
+
+[TestFixture]
+class OverwriteFileVersionTests : TaskTests
+{
+    public OverwriteFileVersionTests()
+    {
+        config = XElement.Parse("<Stamp OverwriteFileVersion=\"false\" />");
+    }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -96,6 +96,9 @@
       <Name>Fody</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
> This branch addresses #13 by adding two config options:
> 
> 1. `OverwriteFileVersion` is set to `true` by default. If it is set to `false`, Stamp will not overwrite the `AssemblyFileVersion` with the `AssemblyVersion`.
> 1. `UseFileVersion` is `false` by default. If it is set to `true`, Stamp will use `AssemblyFileVersion` to construct the `AssemblyInformationalVersion`, rather than using `AssemblyVersion`. Also, if this is set to `true`, `OverwriteFileVersion` will be `false` and will ignore any explicitly set value.
> 
> I included tests for both of these options that mimic `TaskTests`.

Fixes #13, supersedes #22 

to do:

- [x] rebased
- [x] backwardscompatible
- [ ] rename UseFileVersion?  -> AssemblyInformationalSource = AssemblyVersion  | AssemblyFileVersion 
- [ ]  OverwriteFileVersion? -> PreserveFileVersion

readme: https://github.com/304NotModified/Fody.Stamp/tree/pr22b